### PR TITLE
Fix command line parameters (remove -P in front of URI)

### DIFF
--- a/examples/hyperparam/README.rst
+++ b/examples/hyperparam/README.rst
@@ -51,15 +51,15 @@ Runs the Keras deep learning training with default parameters and log it in expe
 
 .. code-block:: bash
 
-    mlflow run -e random --experiment-id <hyperparam_experiment_id>  -P examples/hyperparam
+    mlflow run -e random --experiment-id <hyperparam_experiment_id> examples/hyperparam
 
 .. code-block:: bash
 
-    mlflow run -e gpyopt --experiment-id <hyperparam_experiment_id>  -P examples/hyperparam
+    mlflow run -e gpyopt --experiment-id <hyperparam_experiment_id> examples/hyperparam
 
 .. code-block:: bash
 
-    mlflow run -e hyperopt --experiment-id <hyperparam_experiment_id> -P examples/hyperparam
+    mlflow run -e hyperopt --experiment-id <hyperparam_experiment_id> examples/hyperparam
 
 Runs the hyperparameter tuning with either random search or GpyOpt or Hyperopt and log the
 results under ``hyperparam_experiment_id``.


### PR DESCRIPTION


## What changes are proposed in this pull request?

I removed the `-P` flags in front of `examples/hyperparam` because it gave me the error "Please specify URI" on WSL2 with Ubuntu 20.04.

## How is this patch tested?

Run fixed command 


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Example can't be run with the original command.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
